### PR TITLE
Allow setting cmake generator with environment variable

### DIFF
--- a/src/main/java/hudson/plugins/cmake/CmakeBuilder.java
+++ b/src/main/java/hudson/plugins/cmake/CmakeBuilder.java
@@ -45,6 +45,7 @@ import java.util.Set;
 public class CmakeBuilder extends Builder {
 
 	private static final String CMAKE_EXECUTABLE = "CMAKE_EXECUTABLE";
+        private static final String CMAKE_GENERATOR = "CMAKE_GENERATOR";
 
 	private static final String CMAKE = "cmake";
 	
@@ -204,9 +205,16 @@ public class CmakeBuilder extends Builder {
 			String theInstallDir, String theBuildType) throws IOException,
 			InterruptedException {
 		String cmakeBin = checkCmake(build.getBuiltOn(), listener, envs);
+        
+        String generator = this.generator;
+        
+        if (envs.containsKey(CMAKE_GENERATOR)) {
+            generator = envs.get(CMAKE_GENERATOR);
+        }
+        
     	String cmakeCall = 
     		builderImpl.buildCMakeCall(cmakeBin, 
-    				this.generator,
+    				generator,
     				this.preloadScript, 
     				theSourceDir, 
     				theInstallDir, 

--- a/src/main/resources/hudson/plugins/cmake/CmakeBuilder/help-generator.html
+++ b/src/main/resources/hudson/plugins/cmake/CmakeBuilder/help-generator.html
@@ -19,6 +19,7 @@
  	<li>Eclipse CDT4 - Unix Makefiles</li>
  	<li>Eclipse CDT4 - NMake Makefiles</li>
  	<li>Eclipse CDT4 - MinGW Makefiles</li>
- </ul> 
+ </ul>
+ This can be overridden by environment variable CMAKE_GENERATOR. 
 </p>
 </div>


### PR DESCRIPTION
In the case of running a cmake job on multiple nodes with a matrix project, it
is useful to have a single jenkins job trigger builds with different generators
depending on the resources available on the node (Visual Studio versions, xcode,
makefiles etc). With this patch, each node can specify a generator to be used
when building cmake jobs on it (or anywhere else an environment var can be
defined).
