### PR TITLE
Workaround for cmake 3

### DIFF
--- a/src/main/java/de/marw/cmake/cmakecache/SimpleCMakeCacheTxt.java
+++ b/src/main/java/de/marw/cmake/cmakecache/SimpleCMakeCacheTxt.java
@@ -53,7 +53,7 @@ public class SimpleCMakeCacheTxt {
       for (SimpleCMakeCacheEntry entry : entries) {
         final String toolKey = entry.getKey();
         final String tool = entry.getValue();
-        if ("CMAKE_BUILD_TOOL".equals(toolKey)) {
+        if ("CMAKE_MAKE_PROGRAM".equals(toolKey)) {
           buildTool = tool;
         } else if ("CMAKE_COMMAND".equals(toolKey)) {
           commands.add(tool);
@@ -84,7 +84,7 @@ public class SimpleCMakeCacheTxt {
    * most cases, this method will return the absolute file system path of the
    * tool, such as {@code /usr/bin/make}.
    *
-   * @return the CMAKE_BUILD_TOOL entry from the CMakeCache.txt file or
+   * @return the CMAKE_MAKE_PROGRAM entry from the CMakeCache.txt file or
    *         {@code null} if the file could not be parsed
    */
   public String getBuildTool() {

--- a/src/main/java/hudson/plugins/cmake/BuildToolEntryParser.java
+++ b/src/main/java/hudson/plugins/cmake/BuildToolEntryParser.java
@@ -29,7 +29,7 @@ import de.marw.cmake.cmakecache.CMakeCacheFileParser.EntryFilter;
 import de.marw.cmake.cmakecache.SimpleCMakeCacheEntry;
 
 /**
- * Gets the value of the {@code "CMAKE_BUILD_TOOL"} entry from a cmake cache
+ * Gets the value of the {@code "CMAKE_MAKE_PROGRAM"} entry from a cmake cache
  * file.
  *
  * @author Martin Weber
@@ -39,7 +39,7 @@ public class BuildToolEntryParser implements FilePath.FileCallable<String> {
     private static final long serialVersionUID = 1L;
 
     /**
-     * Parses the cach file and returns value of the {@code "CMAKE_BUILD_TOOL"}
+     * Parses the cach file and returns value of the {@code "CMAKE_MAKE_PROGRAM"}
      * entry.
      *
      * @return the entry value or {@code null} if the file could not be parsed
@@ -57,7 +57,7 @@ public class BuildToolEntryParser implements FilePath.FileCallable<String> {
 
                 @Override
                 public boolean accept(String key) {
-                    return "CMAKE_BUILD_TOOL".equals(key);
+                    return "CMAKE_MAKE_PROGRAM".equals(key);
                 }
             }, result, null);
             if (result.size() > 0) {

--- a/src/main/java/hudson/plugins/cmake/CmakeBuilder.java
+++ b/src/main/java/hudson/plugins/cmake/CmakeBuilder.java
@@ -43,7 +43,7 @@ public class CmakeBuilder extends Builder {
      * build-scripts have been generated for (e.g. /usr/bin/make or
      * /usr/bin/ninja)
      */
-    public static final String ENV_VAR_NAME_CMAKE_BUILD_TOOL = "CMAKE_BUILD_TOOL";
+    public static final String ENV_VAR_NAME_CMAKE_MAKE_PROGRAM = "CMAKE_MAKE_PROGRAM";
 
     /** the name of the cmake tool installation to use for this build step */
     private String installationName;
@@ -245,16 +245,16 @@ public class CmakeBuilder extends Builder {
             FilePath cacheFile = theBuildDir.child("CMakeCache.txt");
             String buildTool = cacheFile.act(new BuildToolEntryParser());
             if (buildTool == null) {
-                listener.error("Failed to get CMAKE_BUILD_TOOL value from "
+                listener.error("Failed to get CMAKE_MAKE_PROGRAM value from "
                         + cacheFile.getRemote());
                 return false; // abort build
             }
             // export the variable..
             EnvVars envVars = new EnvVars(
-                    CmakeBuilder.ENV_VAR_NAME_CMAKE_BUILD_TOOL, buildTool);
+                    CmakeBuilder.ENV_VAR_NAME_CMAKE_MAKE_PROGRAM, buildTool);
             build.getEnvironments().add(Environment.create(envVars));
 //            listener.getLogger().println(
-//                    "Exported CMAKE_BUILD_TOOL=" + buildTool);
+//                    "Exported CMAKE_MAKE_PROGRAM=" + buildTool);
 
             /* invoke each build tool step in build dir */
             for (BuildToolStep step : toolSteps) {

--- a/src/main/resources/hudson/plugins/cmake/CmakeBuilder/help-generator.html
+++ b/src/main/resources/hudson/plugins/cmake/CmakeBuilder/help-generator.html
@@ -18,8 +18,8 @@ Possible generators include:
  <p>
  The build tool chosen by CMake &mdash; corresponding to the generator &mdash;
  is exposed in the
- <code><strong>CMAKE_BUILD_TOOL</strong></code> build environment variable.
- Subsequent build steps may use <code>$CMAKE_BUILD_TOOL</code> 
+ <code><strong>CMAKE_MAKE_PROGRAM</strong></code> build environment variable.
+ Subsequent build steps may use <code>$CMAKE_MAKE_PROGRAM</code> 
  to execute the generated scripts.<br>
  Its actual value is retrieved from the generated CMake cache file
  (<code>CMakeCache.txt</code>). Usually that value is something like 

--- a/src/main/resources/hudson/plugins/cmake/CmakeBuilder/help-runTool.html
+++ b/src/main/resources/hudson/plugins/cmake/CmakeBuilder/help-runTool.html
@@ -1,9 +1,9 @@
 <div>
-Invocations of <code>$CMAKE_BUILD_TOOL</code>, which evaluates to the actual
+Invocations of <code>$CMAKE_MAKE_PROGRAM</code>, which evaluates to the actual
 build tool that operates on the generated build scripts.<br>
 Would run <code>/usr/bin/gmake</code> if, for example, 
 the "Unix Makefiles" generator was specified and the build node
 is runnung under Linux. 
-<code><strong>$CMAKE_BUILD_TOOL</strong></code> will be started directly
+<code><strong>$CMAKE_MAKE_PROGRAM</strong></code> will be started directly
 without any commandline shell.
 </div>

--- a/src/main/resources/hudson/plugins/cmake/CmakeBuilder/help.html
+++ b/src/main/resources/hudson/plugins/cmake/CmakeBuilder/help.html
@@ -1,5 +1,5 @@
 <div>For projects that use CMake to generate build-scripts.
   This causes Jenkins to invoke cmake with the given options.</br>
   Any non-zero exit code during build-script generation causes Jenkins to mark the build as a failure.</br>
-  Exposes the <code><strong>CMAKE_BUILD_TOOL</strong></code> build environment variable.
+  Exposes the <code><strong>CMAKE_MAKE_PROGRAM</strong></code> build environment variable.
 </div>

--- a/src/test/java/hudson/plugins/cmake/JobBuildTest.java
+++ b/src/test/java/hudson/plugins/cmake/JobBuildTest.java
@@ -104,7 +104,7 @@ public class JobBuildTest {
         StringParameterDefinition pd4 = new StringParameterDefinition(
                 "BUILDGENERATOR", "Unix Makefiles");
         StringParameterDefinition pd5 = new StringParameterDefinition(
-                "BUILDTOOL", "make");
+                "BUILDPROGRAM", "make");
         StringParameterDefinition pd6 = new StringParameterDefinition(
                 "PRESCRIPT", "setup/cmake-cache-preload.txt");
         StringParameterDefinition pd7 = new StringParameterDefinition(
@@ -154,7 +154,7 @@ public class JobBuildTest {
         System.out.println(JenkinsRule.getLog(build));
         j.assertBuildStatusSuccess(build);
 
-        assertNotNull(CmakeBuilder.ENV_VAR_NAME_CMAKE_BUILD_TOOL, gevb.value);
+        assertNotNull(CmakeBuilder.ENV_VAR_NAME_CMAKE_MAKE_PROGRAM, gevb.value);
     }
 
     /**
@@ -203,7 +203,7 @@ public class JobBuildTest {
                 BuildListener listener) throws InterruptedException,
                 IOException {
             value = build.getEnvironment(listener).get(
-                    CmakeBuilder.ENV_VAR_NAME_CMAKE_BUILD_TOOL);
+                    CmakeBuilder.ENV_VAR_NAME_CMAKE_MAKE_PROGRAM);
             return true;
         }
 


### PR DESCRIPTION
cmake 3 seems to ignore the `CMAKE_BUILD_TOOL` statement;
If I try to build a project using Ninja as Build tool (set in the Jenkins UI), cmake quits with the following error:
```
ERROR: Failed to get CMAKE_BUILD_TOOL value from
/home/of/buildpath/CMakeCache.txt
```
As `CMAKE_BUILD_TOO`L exists [only for backwards compatability](http://www.cmake.org/cmake/help/v3.0/variable/CMAKE_BUILD_TOOL.html), this was changed.

Changing the `CMAKE_BUILD_TOOL` to `CMAKE_MAKE_PROGRAM` seems to help
