### PR TITLE
User-defined Environment variables are not passed to steps within withCmake

### DIFF
--- a/src/main/java/hudson/plugins/cmake/CmakeBuilderStep.java
+++ b/src/main/java/hudson/plugins/cmake/CmakeBuilderStep.java
@@ -330,7 +330,7 @@ public class CmakeBuilderStep extends AbstractStep {
             }
 
             if (step.getSteps() != null) {
-                final EnvVars envs = new EnvVars();
+                final EnvVars envs = new EnvVars(env);
 
                 String buildTool = null;
                 boolean needBuildTool = false;


### PR DESCRIPTION
For each cmake steps, currently the provided environment is not forwarded